### PR TITLE
Added open keyword for Kotlin version of DemoPlugin

### DIFF
--- a/docs/en/user_guide/introduction/first_test.md
+++ b/docs/en/user_guide/introduction/first_test.md
@@ -157,7 +157,7 @@ package org.mockbukkit.docsdemo
 
 import org.bukkit.plugin.java.JavaPlugin
 
-class DemoPlugin: JavaPlugin() {
+open class DemoPlugin: JavaPlugin() {
 
     override fun onEnable() {
         logger.info("${this.name} enabled")


### PR DESCRIPTION
Added 'open' keyword for Kotlin in 'first_test.md'