### PR TITLE
add open modifies to example kotlin test

### DIFF
--- a/docs/en/user_guide/introduction/first_test.md
+++ b/docs/en/user_guide/introduction/first_test.md
@@ -70,7 +70,7 @@ public class MyPluginTests {
 ```
 
 ```kotlin [Kotlin]
-class MyPluginTests {
+open class MyPluginTests {
 
     private lateinit var server: ServerMock
     private lateinit var plugin: MyPlugin


### PR DESCRIPTION
As mentioned in the block above the code the kotlin classes should be `open`. This modifier was missing in the example